### PR TITLE
change parameters for audio triggers

### DIFF
--- a/AutomaticityTest_ME_v4.m
+++ b/AutomaticityTest_ME_v4.m
@@ -205,7 +205,7 @@ for i=order_autodual %Either [1,2] or [2,1] -> determines the order of the tasks
   % Finger tapping test -> 11 trials, presents letters upon randomized speed
   if i==1
     %Instruction automaticity task finger tapping
-    trig.beep(400, 0.1, 'instructions');
+    trig.beep(440, 0.2, 'instructions');
     Screen('TextSize',window,25);
     DrawFormattedText(window, sprintf('You will now perform the pre-learned sequence for the FINGER tapping task: \n %s \n\n  While you perform the task, letters will be shown on the screen (A,G,O,L). \n The goal is to perform the sequence tapping while counting how many times G is presented. \n After each time you tapped the full sequence, you should tell us how many times G was presented. \n We will perform 11 trails. \n\n Note that during the tapping task you cannot talk. \n Try to keep your body movements as still as possible exept for the right hand. \n\n In between the trials you will see a fixation cross for 20 seconds. \n During the first few seconds you will hear a metronome sound. \n Tap the sequence on this rhythm, which is the same as you studied at home. \n\n We will start with a fixation cross on the screen for 20 seconds. \n After that the first trial will start automatically. \n So start tapping the sequence as soon as a letter on the screen appears. \n When ready: press any key to continue and start the test.', sequenceauto),'center','center', white);
     vbl = Screen('Flip', window);
@@ -220,7 +220,7 @@ for i=order_autodual %Either [1,2] or [2,1] -> determines the order of the tasks
       
       % Always start with a 20-25 seconds fixation cross with 8 seconds of metronome
       % sound
-      trig.beep(400, 0.1, 'rest');
+      trig.beep(440, 0.2, 'rest');
       Screen('TextSize', window, 36);
       Screen('DrawLines', window, allCoords,...
         lineWidthPix, white, [xCenter yCenter], 2);
@@ -230,7 +230,7 @@ for i=order_autodual %Either [1,2] or [2,1] -> determines the order of the tasks
       
       %Presentation of random letters on the screen during the finger
       %tapping test + recording of the key presses
-      trig.beep(400, 0.1, 'finger_auto_dual');
+      trig.beep(440, 0.2, 'finger_auto_dual');
       m=1; % first key press
       %           FlushEvents('keyDown'); % option A: clear all previous key presses from the list
       KbQueueFlush; % option B: clear all previous key presses from the list
@@ -277,7 +277,7 @@ for i=order_autodual %Either [1,2] or [2,1] -> determines the order of the tasks
       
       % Present white fixation cross for some seconds to show that
       % trial is over
-      trig.beep(400, 0.1, 'rest');
+      trig.beep(440, 0.2, 'rest');
       Screen('TextSize', window, 36);
       Screen('DrawLines', window, allCoords,...
         lineWidthPix, white, [xCenter yCenter], 2);
@@ -311,7 +311,7 @@ for i=order_autodual %Either [1,2] or [2,1] -> determines the order of the tasks
     % Foot stomping test -> 11 trials, presents letters upon randomized speed
   elseif i==2
     % Instruction automaticity task foot stomping
-    trig.beep(400, 0.1, 'instructions');
+    trig.beep(440, 0.2, 'instructions');
     Screen('TextSize',window,25);
     DrawFormattedText(window, sprintf('You will now perform the pre-learned sequence for the FOOT stomping task: \n %s \n\n While you perform the task, letters will be shown on the screen (A,G,O,L). \n The goal is to perform the sequence stomping while counting how many times G is presented. \n After each time you stomped the full sequence, you should tell us how many times G was presented. \n We will perform 11 trials. \n\n Note that during the stomping task you cannot talk. \n Try to keep your body movements as still as possible exept for your right leg. \n\n In between the trials you will see a fixation cross for 20 seconds. \n During the first few seconds you will hear a metronome sound. \n Stomp the sequence on this rhythm, which is the same as you studied at home. \n\n We will start with a fixation cross on the screen for 20 seconds. \n After that the first trial will start automatically. \n So start stomping the sequence as soon as a letter on the screen appears. \n When ready: press any key to continue and start the test.', sequenceauto),'center','center', white);
     vbl = Screen('Flip', window);
@@ -327,7 +327,7 @@ for i=order_autodual %Either [1,2] or [2,1] -> determines the order of the tasks
       
       % Always start with a fixation cross and 8 seconds of metronome
       % sound
-      trig.beep(400, 0.1, 'rest');
+      trig.beep(440, 0.2, 'rest');
       Screen('TextSize', window, 36);
       Screen('DrawLines', window, allCoords,...
         lineWidthPix, white, [xCenter yCenter], 2);
@@ -337,7 +337,7 @@ for i=order_autodual %Either [1,2] or [2,1] -> determines the order of the tasks
       
       %Presentation of random letters on the screen during the foot
       %stomping test
-      trig.beep(400, 0.1, 'foot_auto_dual');
+      trig.beep(880, 0.2, 'foot_auto_dual');
       for n=1:N_letters
         % present random letter
         Screen('TextSize', window, 100);
@@ -355,7 +355,7 @@ for i=order_autodual %Either [1,2] or [2,1] -> determines the order of the tasks
       
       % Present white fixation cross for some seconds to show that
       % trial is over
-      trig.beep(400, 0.1, 'rest');
+      trig.beep(440, 0.2, 'rest');
       Screen('TextSize', window, 36);
       Screen('DrawLines', window, allCoords,...
         lineWidthPix, white, [xCenter yCenter], 2);

--- a/ExperimentScript_ME_v4.m
+++ b/ExperimentScript_ME_v4.m
@@ -213,7 +213,7 @@ letters_handnonautodual=struct([]);
 letters_footnonautodual=struct([]);
 
 %Instruction experiment
-trig.beep(400, 0.1, 'instructions');
+trig.beep(440, 0.2, 'instructions');
 Screen('TextSize',window,25);
 DrawFormattedText(window,'You will now start with the experiment. \n You will either start with the automatic tasks, performing the at home studied sequence, \n or with the non-automatic tasks, for which you will be presented with a new sequence, \n which you can study for 10 minutes for each limb. \n Note that for the non-automatic tasks you will also perform an automaticity test (dual task). \n This is the same test as you just did for the automatic (at home studied) sequence. \n\n Detailed instructions will appear at the start of each new task. \n\n Press any key to continue and see with which test you start.','center', 'center', white);
 vbl = Screen('Flip', window);
@@ -232,14 +232,14 @@ for i=order_experiment; %Either [1,2] or [2,1] -> determines the order of the ta
         
         %Determine to start with either hand or foot task.
         for j=order_nonauto %Either [3,4] or [4,3] -> determines the order of the limbs
-            trig.beep(400, 0.1, 'instructions');
+            trig.beep(440, 0.2, 'instructions');
             
             % NON-AUTOMATIC FINGER TAPPING TASK
             if j==3
                 
                 %Non automatic finger tapping task instructions
                 %Practice new sequence
-                trig.beep(400, 0.1, 'practice_finger_nonauto');
+                trig.beep(440, 0.2, 'practice_finger_nonauto');
                 Screen('TextSize', window, 25);
                 DrawFormattedText(window, 'You will now perform the non-automaticity FINGER tapping task. \n For the next 10 minutes you can practice a new sequence for the finger tapping task, \n the same way you practiced at home. \n After that we will start with the finger tapping task. \n Press any key to see the new sequence and start practicing.', 'center', 'center', white);
                 vbl= Screen('Flip', window);
@@ -268,7 +268,7 @@ for i=order_experiment; %Either [1,2] or [2,1] -> determines the order of the ta
                 for l = 1:N_trials %Will perform 11 trials
                     presses_handnonauto(l).key=[];
                     %Rest period between each sequence 20-25 seconds
-                    trig.beep(400, 0.1, 'rest');
+                    trig.beep(440, 0.2, 'rest');
                     % Fixation cross during rest
                     Screen('TextSize', window, 36);        
                     Screen('DrawLines', window, allCoords,...
@@ -278,7 +278,7 @@ for i=order_experiment; %Either [1,2] or [2,1] -> determines the order of the ta
                     WaitSecs(t1+randi(t2));
                     
                     %Red fixation cross during finger tapping trial
-                    trig.beep(400, 0.1, 'finger_nonauto');
+                    trig.beep(440, 0.2, 'finger_nonauto');
                     Screen('TextSize', window, 36);
                     Screen('DrawLines', window, allCoords,...
                         lineWidthPix, [1 0 0], [xCenter yCenter], 2);
@@ -306,7 +306,7 @@ for i=order_experiment; %Either [1,2] or [2,1] -> determines the order of the ta
                 
                 
                 % End of the non-automatic finger tapping task is reached.
-                trig.beep(400, 0.1, 'rest');
+                trig.beep(440, 0.2, 'rest');
                 Screen('TextSize', window, 25);
                 DrawFormattedText(window, 'This is the end of the non-automatic finger tapping task. \n Take a rest if needed. \n When ready: press any key to continue with the automaticity test for this task.', 'center', 'center', white);
                 vbl= Screen('Flip', window);
@@ -314,7 +314,7 @@ for i=order_experiment; %Either [1,2] or [2,1] -> determines the order of the ta
                 
                 
                 %Instruction automaticity task finger tapping
-                trig.beep(400, 0.1, 'instructions');
+                trig.beep(440, 0.2, 'instructions');
                 Screen('TextSize',window,25);
                 DrawFormattedText(window, sprintf('You will now perform the sequence you just learned during an automaticity test for the FINGER tapping task. \n %s \n\n  While you perform the task, letters will be shown on the screen (A,G,O,L). \n The goal is to perform the sequence tapping while counting how many times G is presented. \n After each time you tapped the full sequence, you should tell us how many times G was presented. \n We will perform 11 trails. \n\n Note that during the tapping task you cannot talk. \n Try to keep your body movements as still as possible exept for the right hand. \n\n In between the trials you will see a white fixation cross for 20 seconds. \n During the first few seconds you will hear a metronome sound. \n Tap the sequence on this rhythm, which is the same as you practiced before. \n \n We will start with a fixation cross on the screen for 20 seconds. \n After that the first trial will start automatically. \n So start tapping the sequence as soon as a letter on the screen appears. \n When ready: press any key to continue and start the test.', sequencenonauto),'center','center', white);
                 vbl = Screen('Flip', window);
@@ -329,7 +329,7 @@ for i=order_experiment; %Either [1,2] or [2,1] -> determines the order of the ta
                     
                     % Always start with a 20-25 seconds fixation cross with 8 seconds of metronome
                     % sound
-                    trig.beep(400, 0.1, 'rest');
+                    trig.beep(440, 0.2, 'rest');
                     Screen('TextSize', window, 36);
                     Screen('DrawLines', window, allCoords,...
                         lineWidthPix, white, [xCenter yCenter], 2);
@@ -339,7 +339,7 @@ for i=order_experiment; %Either [1,2] or [2,1] -> determines the order of the ta
                     
                     %Presentation of random letters on the screen during the finger
                     %tapping test + recording of the key presses
-                    trig.beep(400, 0.1, 'finger_nonauto_dual');
+                    trig.beep(440, 0.2, 'finger_nonauto_dual');
                     v=1; % first key press
                     %FlushEvents('keyDown'); % option A: clear all previous key presses from the list
                     KbQueueFlush; % option B: clear all previous key presses from the list
@@ -386,7 +386,7 @@ for i=order_experiment; %Either [1,2] or [2,1] -> determines the order of the ta
                     
                     % Present white fixation cross for some seconds to show that
                     % trial is over
-                    trig.beep(400, 0.1, 'rest');
+                    trig.beep(440, 0.2, 'rest');
                     Screen('TextSize', window, 36);
                     Screen('DrawLines', window, allCoords,...
                         lineWidthPix, white, [xCenter yCenter], 2);
@@ -424,7 +424,7 @@ for i=order_experiment; %Either [1,2] or [2,1] -> determines the order of the ta
                
                 %Non automatic foot stomping task instructions
                 %Practice new sequence
-                trig.beep(400, 0.1, 'practice_foot_nonauto');
+                trig.beep(440, 0.2, 'practice_foot_nonauto');
                 Screen('TextSize', window, 25);
                 DrawFormattedText(window, 'You will now perform the non-automaticity FOOT stomping task. \n For the next 10 minutes you can practice the new sequence for the foot stomping task. \n After that the experiment for the foot stomping task will start. \n\n\n Press any key to see the new sequence and start practicing.', 'center', 'center', white);
                 vbl= Screen('Flip', window);
@@ -443,7 +443,7 @@ for i=order_experiment; %Either [1,2] or [2,1] -> determines the order of the ta
                 KbStrokeWait; %wait for response to terminate instructions
                 
                 %Instructions non-automatic foot stomping task
-                trig.beep(400, 0.1, 'instructions');
+                trig.beep(440, 0.2, 'instructions');
                 Screen('TextSize',window,25);
                 DrawFormattedText(window, sprintf('You will now perform the foot stomping experiment for the sequence you just practiced (non-automatic). \n There is a total of 11 trials, so performing the sequence 11 times. \n In between each trial there is a rest period of 20 seconds. \n During this rest you will hear a metronome sound, stomp the sequence according to this interval sound. \n Trials and rest periods are indicated with red(= trial) and white(=rest) fixation crosses presented on the screen. \n\n When the experiment starts you cannot talk anymore. \n Furthermore, it is important to stay still except for your right leg. \n If you press any key, the experiment starts right away. \n It will start with a rest period. \n Whenever a RED fixation cross appears on the screen, you should start stomping the sequence: \n %s \n When ready: press any key to start the foot stomping experiment.', sequencenonauto),'center', 'center', white);
                 vbl = Screen('Flip', window);
@@ -454,7 +454,7 @@ for i=order_experiment; %Either [1,2] or [2,1] -> determines the order of the ta
                 for n = 1:N_trials %Will perform 11 trials
                     
                     % Rest period 20-25 seconds
-                    trig.beep(400, 0.1, 'rest');
+                    trig.beep(440, 0.2, 'rest');
                     Screen('TextSize', window, 36);
                     Screen('DrawLines', window, allCoords,...
                         lineWidthPix, white, [xCenter yCenter], 2);
@@ -463,7 +463,7 @@ for i=order_experiment; %Either [1,2] or [2,1] -> determines the order of the ta
                     WaitSecs(t1+randi(t2))
                     
                     % Red fixation cross during trial
-                    trig.beep(400, 0.1, 'foot_nonauto');
+                    trig.beep(880, 0.2, 'foot_nonauto');
                     Screen('TextSize', window, 36);
                     Screen('DrawLines', window, allCoords,...
                         lineWidthPix, [1 0 0], [xCenter yCenter], 2);
@@ -474,7 +474,7 @@ for i=order_experiment; %Either [1,2] or [2,1] -> determines the order of the ta
                 end
                 
                 % End of the non-automatic foot stomping task
-                trig.beep(400, 0.1, 'rest');
+                trig.beep(440, 0.2, 'rest');
                 Screen('TextSize', window, 25);
                 DrawFormattedText(window, 'This is the end of the non-automatic foot stomping task. \n Take a rest if needed. \n When ready: press any key to continue with the automaticity test.', 'center', 'center', white);
                 vbl= Screen('Flip', window);
@@ -482,7 +482,7 @@ for i=order_experiment; %Either [1,2] or [2,1] -> determines the order of the ta
                 trig.digitalout(0, 'stop_rec'); % stops the recording of xsens
                 
                 % Instruction automaticity task foot stomping
-                trig.beep(400, 0.1, 'instructions');
+                trig.beep(440, 0.2, 'instructions');
                 Screen('TextSize',window,25);
                 DrawFormattedText(window, sprintf('You will now perform the sequence you just learned for an automaticity test for the FOOT stomping task. \n %s \n\n While you perform the task, letters will be shown on the screen (A,G,O,L). \n The goal is to perform the sequence stomping while counting how many times G is presented. \n After each time you stomped the full sequence, you should tell us how many times G was presented. \n We will perform 11 trials. \n\n Note that during the stomping task you cannot talk. \n Try to keep your body movements as still as possible exept for your right leg. \n\n In between the trials you will see a fixation cross for 20 seconds. \n During the first few seconds you will hear a metronome sound. \n Stomp the sequence on this rhythm, which is the same as you studied at home. \n\n We will start with a fixation cross on the screen for 20 seconds. \n After that the first trial will start automatically. \n So start stomping the sequence as soon as a letter on the screen appears. \n When ready: press any key to continue and start the test.', sequencenonauto),'center','center', white);
                 vbl = Screen('Flip', window);
@@ -498,7 +498,7 @@ for i=order_experiment; %Either [1,2] or [2,1] -> determines the order of the ta
                     
                     % Always start with a fixation cross and 5 seconds of metronome
                     % sound
-                    trig.beep(400, 0.1, 'rest');
+                    trig.beep(440, 0.2, 'rest');
                     Screen('TextSize', window, 36);
                     Screen('DrawLines', window, allCoords,...
                         lineWidthPix, white, [xCenter yCenter], 2);
@@ -508,7 +508,7 @@ for i=order_experiment; %Either [1,2] or [2,1] -> determines the order of the ta
                     
                     %Presentation of random letters on the screen during the foot
                     %stomping test
-                    trig.beep(400, 0.1, 'foot_nonauto_dual');
+                    trig.beep(880, 0.2, 'foot_nonauto_dual');
                     for w=1:N_letters
                         % present random letter
                         Screen('TextSize', window, 100);
@@ -526,7 +526,7 @@ for i=order_experiment; %Either [1,2] or [2,1] -> determines the order of the ta
                     
                     % Present white fixation cross for some seconds to show that
                     % trial is over
-                    trig.beep(400, 0.1, 'rest');
+                    trig.beep(440, 0.2, 'rest');
                     Screen('TextSize', window, 36);
                     Screen('DrawLines', window, allCoords,...
                         lineWidthPix, white, [xCenter yCenter], 2);
@@ -564,7 +564,7 @@ for i=order_experiment; %Either [1,2] or [2,1] -> determines the order of the ta
     if i==2; %Start with the automatic tasks
         
         % Show instructions
-        trig.beep(400, 0.1, 'instructions');
+        trig.beep(440, 0.2, 'instructions');
         Screen('TextSize', window, 25);
         DrawFormattedText(window, 'AUTOMATICITY TASK \n\n You will perform the finger tapping and foot stomping task for the sequence you studied at home. \n You will either start with the finger tapping or foot stomping task. \n Press any key to continue.', 'center', 'center', white);
         vbl= Screen('Flip', window);
@@ -585,7 +585,7 @@ for i=order_experiment; %Either [1,2] or [2,1] -> determines the order of the ta
                 for o = 1:N_trials % Will perform 11 trials
                     presses_handauto(o).key=[];
                     %Rest period 20-25 seconds
-                    trig.beep(400, 0.1, 'rest');
+                    trig.beep(440, 0.2, 'rest');
                     Screen('TextSize', window, 36);
                     Screen('DrawLines', window, allCoords,...
                         lineWidthPix, white, [xCenter yCenter], 2);
@@ -594,7 +594,7 @@ for i=order_experiment; %Either [1,2] or [2,1] -> determines the order of the ta
                     WaitSecs(t1+randi(t2))
                     
                     % Red fixation cross during trial
-                    trig.beep(400, 0.1, 'finger_auto');
+                    trig.beep(440, 0.2, 'finger_auto');
                     Screen('TextSize', window, 36);
                     Screen('DrawLines', window, allCoords,...
                         lineWidthPix, [1 0 0], [xCenter yCenter], 2);
@@ -622,7 +622,7 @@ for i=order_experiment; %Either [1,2] or [2,1] -> determines the order of the ta
                 end
                 
                 %End of the automatic finger tapping task
-                trig.beep(400, 0.1, 'rest');
+                trig.beep(440, 0.2, 'rest');
                 Screen('TextSize', window, 25);
                 DrawFormattedText(window, 'This is the end of the automatic finger tapping task. \n You can take a rest if needed. \n Whenever you feel ready, \n press any key to continue with the rest of the experiment.', 'center', 'center', white);
                 vbl= Screen('Flip', window);
@@ -634,7 +634,7 @@ for i=order_experiment; %Either [1,2] or [2,1] -> determines the order of the ta
             % Automatic foot stomping task
             if k==6;                
                 % Automatic foot stomping instructions
-                trig.beep(400, 0.1, 'instructions');
+                trig.beep(440, 0.2, 'instructions');
                 Screen('TextSize',window,25);
                 DrawFormattedText(window, sprintf('You will now perform the FOOT stomping experiment for the sequence you studied at home (automatic). \n %s \n\n There is a total of 11 trials, so performing the sequence 11 times. \n In between each trial there is a rest period of 20 seconds. \n During this rest you will hear a metronome sound, stomp the sequence according to this interval sound. \n Trials and rest periods are indicated with red(= trial) and white(= rest)fixation crosses presented on the screen. \n\n When the experiment starts you cannot talk anymore. \n Furthermore, it is important to stay still except for your right leg. \n If you press any key, the experiment starts right away. \n It will start with a rest period. \n Whenever a RED fixation cross appears on the screen, you should start stomping the sequence. \n When ready: press any key to start the foot stomping experiment.', sequenceauto), 'center', 'center', white);
                 vbl = Screen('Flip', window);
@@ -645,7 +645,7 @@ for i=order_experiment; %Either [1,2] or [2,1] -> determines the order of the ta
                 for q = 1:N_trials % Will perform 11 trials
                     
                     % Rest period 20-25 seconds
-                    trig.beep(400, 0.1, 'rest');
+                    trig.beep(440, 0.2, 'rest');
                     %fixation cross
                     Screen('TextSize', window, 36);
                     Screen('DrawLines', window, allCoords,...
@@ -655,7 +655,7 @@ for i=order_experiment; %Either [1,2] or [2,1] -> determines the order of the ta
                     WaitSecs(t1+randi(t2))
                     
                     %Red fixation cross during trial
-                    trig.beep(400, 0.1, 'foot_auto');
+                    trig.beep(880, 0.2, 'foot_auto');
                     Screen('TextSize', window, 36);
                     Screen('DrawLines', window, allCoords,...
                         lineWidthPix, [1 0 0], [xCenter yCenter], 2);
@@ -665,7 +665,7 @@ for i=order_experiment; %Either [1,2] or [2,1] -> determines the order of the ta
                 end
                 
                 % End of the automatic foot stomping task.
-                trig.beep(400, 0.1, 'rest');
+                trig.beep(440, 0.2, 'rest');
                 Screen('TextSize', window, 25);
                 DrawFormattedText(window, 'This is the end of the automatic foot stomping task. \n You can take a rest if needed. \n Whenever you are ready, \n press any key to continue with the rest of the experiment.', 'center', 'center', white);
                 vbl= Screen('Flip', window);


### PR DESCRIPTION
set all audio triggers to 440 Hz and 200 msec, except all foot-related trials (880 Hz, 200 msec)